### PR TITLE
Update Gitalk to 1.5.2 to fix bug

### DIFF
--- a/layout/_partial/post/gitalk.ejs
+++ b/layout/_partial/post/gitalk.ejs
@@ -1,7 +1,7 @@
 <% if (theme.gitalk.enable) { %>
 <div class="gitalk" id="gitalk-container"></div>
-<%- css('https://cdn.jsdelivr.net/npm/gitalk@1.5.0/dist/gitalk.css') %>
-<%- js('https://cdn.jsdelivr.net/npm/gitalk@1.5.0/dist/gitalk.min.js') %>
+<%- css('https://cdn.jsdelivr.net/npm/gitalk@1.5.2/dist/gitalk.css') %>
+<%- js('https://cdn.jsdelivr.net/npm/gitalk@1.5.2/dist/gitalk.min.js') %>
 <%- js('https://cdn.jsdelivr.net/npm/blueimp-md5@2.10.0/js/md5.min.js') %>
 <script type="text/javascript">
   var gitalk = new Gitalk({


### PR DESCRIPTION
 Gitalk 1.5.2 fixed GitHub app API query parameter deprecation problem now (gitalk/gitalk#346).