### PR TITLE
增加生成的网页中的lang根据config.language来定义的特性

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
+
+<% if (config.language){ %>
+<html lang="<%= config.language %>" >
+<% } else { %>
 <html lang="en">
+<% }%>
 
 <head>
   <meta charset="utf-8" />


### PR DESCRIPTION
目前生成的网页中的<html lang="en">永远为英语，没有根据config文件中的配置而改变。