### PR TITLE
Use null when configuring themes using ‘theme_config’ to cancel the default menu item

### DIFF
--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -7,9 +7,11 @@
   <% } %>
   <ul class="nav nav-main">
     <% for (var i in theme.menu){ %>
-    <li class="nav-item">
-      <a class="nav-item-link" href="<%- url_for(theme.menu[i]) %>"><%= i %></a>
-    </li>
+      <% if (theme.menu[i] != null){ %>
+        <li class="nav-item">
+          <a class="nav-item-link" href="<%- url_for(theme.menu[i]) %>"><%= i %></a>
+        </li>
+      <% } %>
     <% } %>
   </ul>
 </nav>


### PR DESCRIPTION
使用hexo的‘theme_config’配置主题时，使用null来取消默认主题配置文件中的菜单项。
![image](https://user-images.githubusercontent.com/19186382/87687219-0e892400-c7b8-11ea-8002-f923f206d5cc.png)
![image](https://user-images.githubusercontent.com/19186382/87687273-219bf400-c7b8-11ea-9b81-459805370f1b.png)
