### PR TITLE
实现版权声明内容自定义。

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -47,7 +47,11 @@
         <li>
           <i class="ri-copyright-line"></i>
           <strong><%= __('post.copyright_title') %>： </strong>
+          <% if (post.copyright_content) { %>
+          <%= post.copyright_content %>
+          <% } else { %>
           <%= __('post.copyright_content') %>
+          <% } %>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
通过 Front-matter 实现针对特定文章的版权声明内容自定义。  
例如：  
copyright_content: 本文章遵守 CC BY-SA 4.0 协议。