### PR TITLE
New layout: plain-page.

### DIFF
--- a/layout/plain-page
+++ b/layout/plain-page
@@ -1,0 +1,4 @@
+<section class="outer">
+  <h1 class="page-type-title"><%= page.title %></h1>
+  <%- page.content %>
+</section>


### PR DESCRIPTION
Added a new layout to provide a plain look which is similar to built-in pages. It has a “page-type-title” and removes advance functions such as sharing. When switching pages in the sidebar, readers will have a constant experience. To use this layout, add “layout: plain-page” to Front-matter.

添加了一种新的布局“plain-page”以提供类似内置页面（「归档」、「分类」、「标签」、「友链」等）的外观。它使用一个左对齐的标题（page-type-title）并且移除了「分享」这类高级功能。用户在侧边栏切换页面时能得到更连贯的阅读体验。在 Front-matter 中添加“layout: plain-page”来使用这种布局。